### PR TITLE
feat: add project listing page

### DIFF
--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,0 +1,24 @@
+export interface Project {
+  id: string
+  title: string
+  updatedAt: string
+}
+
+const STORAGE_KEY = 'projects'
+
+export function getProjects(): Project[] {
+  if (typeof window === 'undefined') return []
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (!raw) return []
+  try {
+    return JSON.parse(raw) as Project[]
+  } catch {
+    return []
+  }
+}
+
+export function deleteProject(id: string): void {
+  if (typeof window === 'undefined') return
+  const projects = getProjects().filter((p) => p.id !== id)
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(projects))
+}

--- a/src/pages/projekte.tsx
+++ b/src/pages/projekte.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { getProjects, deleteProject, Project } from '@/lib/projects'
+
+export default function ProjektePage() {
+  const [projects, setProjects] = useState<Project[]>([])
+
+  const refresh = () => {
+    setProjects(getProjects())
+  }
+
+  useEffect(() => {
+    refresh()
+  }, [])
+
+  const handleDelete = (id: string) => {
+    deleteProject(id)
+    refresh()
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-xl font-bold">Projekte</h1>
+      <div className="mb-4">
+        <Link href="/projekt/neu" className="px-4 py-2 bg-blue-500 text-white rounded">
+          Neues Projekt
+        </Link>
+      </div>
+      <ul className="space-y-2">
+        {projects.map((p) => (
+          <li key={p.id} className="flex items-center space-x-4">
+            <span className="flex-1">
+              {p.title} – {p.updatedAt}
+            </span>
+            <Link href={`/projekt/${p.id}`} className="px-2 py-1 bg-gray-200 rounded">
+              Öffnen
+            </Link>
+            <button
+              onClick={() => handleDelete(p.id)}
+              className="px-2 py-1 bg-red-500 text-white rounded"
+            >
+              Löschen
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add helper for managing projects in local storage
- add page to list projects with open/delete options and link to create

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af22f75354833293c82e225f1ced90