### PR TITLE
feat: add upside potential scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,18 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Upside-Potenzial
+
+Die Webapp unterstützt frei definierbare Upside-Szenarien (z. B. Hotel-Umwidmung oder Dachausbau). Jedes aktive Szenario fügt ab dem eingestellten Startjahr zusätzliche Erträge hinzu und berücksichtigt einmalige CapEx-Kosten. Aus den Cashflows wird ein neuer IRR berechnet.
+
+**Berechnungsschritte:**
+
+1. Zusätzlicher Jahresertrag = `addedSqm × newRentPerSqm × 12 × occupancyPct/100`
+2. Upside-Cashflow = Basis-Cashflow + Σ Zusatzerträge − CapEx im Startjahr
+3. `irrDelta = max(0, irrUpside − irrBasis)`
+4. `pAvg = Durchschnitt der Wahrscheinlichkeit aller aktiven Upsides`
+5. `pWeighted = irrDelta × (pAvg/100)`
+6. Bonus-Punkte `= clamp((pWeighted / 0.03) × 10, 0, 10)`
+
+Beispiel: Erhöht ein Upside den IRR um 1.5 pp und hat eine Eintrittswahrscheinlichkeit von 50 %, ergibt das `pWeighted = 0.75` pp und somit rund `2.5` Bonuspunkte.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('jest').Config} */
+const config = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+};
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "export": "next export",
     "start": "next start -p $PORT",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "jest"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
@@ -16,6 +17,7 @@
     "file-saver": "^2.0.5",
     "jszip": "^3.10.1",
     "lucide-react": "^0.541.0",
+    "nanoid": "^5.0.7",
     "next": "15.5.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
@@ -31,6 +33,9 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.5.0",
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.7",
     "typescript": "^5"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,9 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { TopBar } from "@/components/TopBar";
 import { SettingSection } from "@/components/SettingSection";
+import UpsideForm from "@/components/UpsideForm";
+import { useUpside } from "@/hooks/useUpside";
+import { irr } from "@/lib/upside";
 import {
   CheckCircle2,
   Circle,
@@ -642,6 +645,13 @@ export default function InvestmentCaseLB33() {
   const PLAN_30Y = useMemo(() => buildPlan(30, fin, cfg), [fin, cfg]);
   const PLAN_15Y = useMemo(() => PLAN_30Y.slice(0, 15), [PLAN_30Y]);
 
+  const cashflowsBasis = useMemo(
+    () => [-(cfg.kaufpreis * (1 + cfg.nebenkosten)), ...PLAN_15Y.map((r) => r.fcf)],
+    [cfg.kaufpreis, cfg.nebenkosten, PLAN_15Y]
+  );
+  const irrBasis = useMemo(() => irr(cashflowsBasis), [cashflowsBasis]);
+  const upsideState = useUpside(cashflowsBasis, irrBasis);
+
   const cfPosAb = useMemo(() => {
     const idx = PLAN_30Y.findIndex((r) => r.fcf > 0);
     return idx >= 0 ? idx + 1 : 0;
@@ -832,7 +842,7 @@ export default function InvestmentCaseLB33() {
         ? 0
         : Math.max(0, Math.min(1, (basisDSCR - 1) / 0.5)) * 100;
 
-    const upside = texts.upsideText ? 100 : 0;
+    const upside = upsideState.bonus * 10;
 
     const filled = [
       cfg.adresse,
@@ -870,7 +880,7 @@ export default function InvestmentCaseLB33() {
         : "Cashflow bleibt negativ",
       `DSCR ${basisDSCR.toFixed(2)}`,
     ];
-    if (texts.upsideTitle) bullets.push(texts.upsideTitle);
+    if (upsideState.bonus > 0 && texts.upsideTitle) bullets.push(texts.upsideTitle);
     if (dataQuality < 100) bullets.push("Daten teilweise unvollständig");
 
     return {
@@ -899,14 +909,15 @@ export default function InvestmentCaseLB33() {
       fin.annuitaet,
       texts.upsideText,
       texts.upsideTitle,
+      upsideState.bonus,
       cfg.adresse,
-    cfg.kaufpreis,
-    cfg.nebenkosten,
-    cfg.ekQuote,
-    cfg.tilgung,
-    cfg.laufzeit,
-    cfg.units,
-  ]);
+      cfg.kaufpreis,
+      cfg.nebenkosten,
+      cfg.ekQuote,
+      cfg.tilgung,
+      cfg.laufzeit,
+      cfg.units,
+    ]);
 
   const scoreNarrative = useMemo(() => {
     const reasons = evaluation.bullets.join(". ");
@@ -1249,6 +1260,16 @@ export default function InvestmentCaseLB33() {
               </div>
             </SettingSection>
 
+            <SettingSection title="Upside-Potenzial" icon={TrendingUp}>
+              <UpsideForm
+                scenarios={upsideState.scenarios}
+                add={upsideState.add}
+                update={upsideState.update}
+                duplicate={upsideState.duplicate}
+                remove={upsideState.remove}
+              />
+            </SettingSection>
+
             <SettingSection title="Uploads" icon={Upload}>
               <div className="space-y-6">
                 <div>
@@ -1569,6 +1590,19 @@ export default function InvestmentCaseLB33() {
                 <li key={i}>{b}</li>
               ))}
             </ul>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="max-w-6xl mx-auto px-6 mt-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Upside-Bonus</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm">
+              IRR-Basis {(irrBasis * 100).toFixed(1)} %, IRR-Upside {(upsideState.irrUpside * 100).toFixed(1)} %, Δ = ({((upsideState.irrUpside - irrBasis) * 100).toFixed(2)} × {upsideState.pAvg.toFixed(0)}%) = {(upsideState.pWeighted * 100).toFixed(2)} %-Punkte → Bonus {upsideState.bonus}/10.
+            </p>
           </CardContent>
         </Card>
       </section>

--- a/src/components/UpsideCard.tsx
+++ b/src/components/UpsideCard.tsx
@@ -1,0 +1,147 @@
+import React from "react";
+import type { UpsideScenario, UpsideType } from "@/lib/upside";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Copy, Trash2 } from "lucide-react";
+
+interface UpsideCardProps {
+  scenario: UpsideScenario;
+  onChange: (patch: Partial<UpsideScenario>) => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+}
+
+const TYPES: UpsideType[] = [
+  "Umwidmung_Hotel",
+  "Dachausbau",
+  "Airbnb",
+  "Sanierung_Mietanhebung",
+  "Nachverdichtung",
+  "Sonstiges",
+];
+
+export function UpsideCard({ scenario, onChange, onDuplicate, onDelete }: UpsideCardProps) {
+  return (
+    <Card className="mb-4">
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="flex items-center gap-2">
+          <input
+            className="border rounded px-2 py-1 text-sm w-40"
+            value={scenario.title}
+            onChange={(e) => onChange({ title: e.target.value })}
+            title="Titel für dieses Upside-Szenario"
+          />
+          <label className="flex items-center gap-1 text-sm">
+            <input
+              type="checkbox"
+              checked={scenario.active}
+              onChange={() => onChange({ active: !scenario.active })}
+              title="Szenario aktivieren/deaktivieren"
+            />
+            Aktiv
+          </label>
+        </CardTitle>
+        <div className="flex gap-2">
+          <Button variant="ghost" size="icon" onClick={onDuplicate} title="Duplizieren">
+            <Copy className="w-4 h-4" />
+          </Button>
+          <Button variant="ghost" size="icon" onClick={onDelete} title="Löschen">
+            <Trash2 className="w-4 h-4" />
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="grid grid-cols-2 gap-2 text-sm">
+        <label className="flex flex-col" title="Art des Upside-Potenzials">
+          Art
+          <select
+            className="border rounded px-1 py-1"
+            value={scenario.type}
+            onChange={(e) => onChange({ type: e.target.value as UpsideType })}
+          >
+            {TYPES.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col" title="Ab welchem Jahr wirkt der Upside">
+          Startjahr
+          <input
+            type="number"
+            min={1}
+            className="border rounded px-1 py-1"
+            value={scenario.startYear}
+            onChange={(e) => onChange({ startYear: Number(e.target.value) })}
+          />
+        </label>
+        <label className="flex flex-col" title="Einmalige Investition in EUR">
+          CapEx €
+          <input
+            type="number"
+            min={0}
+            className="border rounded px-1 py-1"
+            value={scenario.capex}
+            onChange={(e) => onChange({ capex: Number(e.target.value) })}
+          />
+        </label>
+        <label className="flex flex-col" title="AfA-Satz auf CapEx, optional">
+          AfA %
+          <input
+            type="number"
+            min={0}
+            className="border rounded px-1 py-1"
+            value={scenario.capexAfaPct ?? ""}
+            onChange={(e) =>
+              onChange({ capexAfaPct: e.target.value ? Number(e.target.value) : undefined })
+            }
+          />
+        </label>
+        <label className="flex flex-col" title="Zusätzliche Fläche in Quadratmeter">
+          +m²
+          <input
+            type="number"
+            min={0}
+            className="border rounded px-1 py-1"
+            value={scenario.addedSqm}
+            onChange={(e) => onChange({ addedSqm: Number(e.target.value) })}
+          />
+        </label>
+        <label className="flex flex-col" title="Erwartete Miete pro m²">
+          Miete €/m²
+          <input
+            type="number"
+            min={0}
+            className="border rounded px-1 py-1"
+            value={scenario.newRentPerSqm}
+            onChange={(e) => onChange({ newRentPerSqm: Number(e.target.value) })}
+          />
+        </label>
+        <label className="flex flex-col" title="Auslastung in Prozent">
+          Auslastung %
+          <input
+            type="number"
+            min={0}
+            max={100}
+            className="border rounded px-1 py-1"
+            value={scenario.occupancyPct}
+            onChange={(e) => onChange({ occupancyPct: Number(e.target.value) })}
+          />
+        </label>
+        <label className="flex flex-col" title="Eintrittswahrscheinlichkeit in Prozent">
+          Wahrscheinlichkeit %
+          <input
+            type="number"
+            min={0}
+            max={100}
+            className="border rounded px-1 py-1"
+            value={scenario.probabilityPct}
+            onChange={(e) => onChange({ probabilityPct: Number(e.target.value) })}
+          />
+        </label>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default UpsideCard;

--- a/src/components/UpsideForm.tsx
+++ b/src/components/UpsideForm.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+import UpsideCard from "@/components/UpsideCard";
+import type { UpsideScenario } from "@/lib/upside";
+
+interface UpsideFormProps {
+  scenarios: UpsideScenario[];
+  add: () => void;
+  update: (id: string, patch: Partial<UpsideScenario>) => void;
+  duplicate: (id: string) => void;
+  remove: (id: string) => void;
+}
+
+export function UpsideForm({
+  scenarios,
+  add,
+  update,
+  duplicate,
+  remove,
+}: UpsideFormProps) {
+  return (
+    <div>
+      {scenarios.map((s) => (
+        <UpsideCard
+          key={s.id}
+          scenario={s}
+          onChange={(patch) => update(s.id, patch)}
+          onDuplicate={() => duplicate(s.id)}
+          onDelete={() => remove(s.id)}
+        />
+      ))}
+      <Button variant="outline" size="sm" onClick={add} className="gap-1">
+        Upside hinzufügen
+      </Button>
+    </div>
+  );
+}
+
+export default UpsideForm;

--- a/src/hooks/useUpside.ts
+++ b/src/hooks/useUpside.ts
@@ -1,0 +1,85 @@
+import { useCallback, useMemo, useState } from "react";
+import { nanoid } from "nanoid";
+import type { UpsideScenario, UpsideCalculationResult } from "@/lib/upside";
+import { calculateUpside } from "@/lib/upside";
+
+export interface UseUpsideResult extends UpsideCalculationResult {
+  scenarios: UpsideScenario[];
+  add: () => void;
+  update: (id: string, patch: Partial<UpsideScenario>) => void;
+  duplicate: (id: string) => void;
+  remove: (id: string) => void;
+  toggle: (id: string) => void;
+}
+
+const DEFAULT_SCENARIO: Omit<UpsideScenario, "id"> = {
+  active: true,
+  type: "Umwidmung_Hotel",
+  title: "Upside 1",
+  startYear: 5,
+  probabilityPct: 50,
+  capex: 0,
+  addedSqm: 0,
+  newRentPerSqm: 0,
+  occupancyPct: 90,
+  capexAfaPct: undefined,
+  remarks: "",
+};
+
+export function useUpside(
+  cashflowsBasis: number[],
+  irrBasis: number
+): UseUpsideResult {
+  const [scenarios, setScenarios] = useState<UpsideScenario[]>([]);
+
+  const add = useCallback(() => {
+    setScenarios((prev) => [
+      ...prev,
+      { ...DEFAULT_SCENARIO, id: nanoid(), title: `Upside ${prev.length + 1}` },
+    ]);
+  }, []);
+
+  const update = useCallback((id: string, patch: Partial<UpsideScenario>) => {
+    setScenarios((prev) =>
+      prev.map((s) => (s.id === id ? { ...s, ...patch } : s))
+    );
+  }, []);
+
+  const duplicate = useCallback((id: string) => {
+    setScenarios((prev) => {
+      const orig = prev.find((s) => s.id === id);
+      if (!orig) return prev;
+      return [
+        ...prev,
+        { ...orig, id: nanoid(), title: `${orig.title} Kopie` },
+      ];
+    });
+  }, []);
+
+  const remove = useCallback((id: string) => {
+    setScenarios((prev) => prev.filter((s) => s.id !== id));
+  }, []);
+
+  const toggle = useCallback((id: string) => {
+    setScenarios((prev) =>
+      prev.map((s) => (s.id === id ? { ...s, active: !s.active } : s))
+    );
+  }, []);
+
+  const result = useMemo(
+    () => calculateUpside(cashflowsBasis, irrBasis, scenarios),
+    [cashflowsBasis, irrBasis, scenarios]
+  );
+
+  return {
+    scenarios,
+    add,
+    update,
+    duplicate,
+    remove,
+    toggle,
+    ...result,
+  };
+}
+
+export default useUpside;

--- a/src/lib/__tests__/upside.test.ts
+++ b/src/lib/__tests__/upside.test.ts
@@ -1,0 +1,59 @@
+import { calculateUpside, irr } from "../upside";
+import type { UpsideScenario } from "../upside";
+
+test("irrDelta is computed", () => {
+  const base = [-100, 30, 30, 30, 30];
+  const irrBasis = irr(base);
+  const scenario: UpsideScenario = {
+    id: "u1",
+    active: true,
+    type: "Umwidmung_Hotel",
+    title: "Test",
+    startYear: 1,
+    addedSqm: 1,
+    newRentPerSqm: 0.0833333333,
+    occupancyPct: 100,
+    capex: 0,
+    probabilityPct: 100,
+  };
+  const res = calculateUpside(base, irrBasis, [scenario]);
+  expect(res.irrDelta).toBeCloseTo(0.014825, 5);
+});
+
+test("pWeighted uses probability", () => {
+  const base = [-100, 30, 30, 30, 30];
+  const irrBasis = irr(base);
+  const scenario: UpsideScenario = {
+    id: "u1",
+    active: true,
+    type: "Umwidmung_Hotel",
+    title: "Test",
+    startYear: 1,
+    addedSqm: 1,
+    newRentPerSqm: 0.0833333333,
+    occupancyPct: 100,
+    capex: 0,
+    probabilityPct: 50,
+  };
+  const res = calculateUpside(base, irrBasis, [scenario]);
+  expect(res.pWeighted).toBeCloseTo(0.0074125, 5);
+});
+
+test("mapping to bonus points", () => {
+  const base = [-100, 30, 30, 30, 30];
+  const irrBasis = irr(base);
+  const scenario: UpsideScenario = {
+    id: "u1",
+    active: true,
+    type: "Umwidmung_Hotel",
+    title: "Test",
+    startYear: 1,
+    addedSqm: 1,
+    newRentPerSqm: 0.25,
+    occupancyPct: 100,
+    capex: 0,
+    probabilityPct: 100,
+  };
+  const res = calculateUpside(base, irrBasis, [scenario]);
+  expect(res.bonus).toBe(10);
+});

--- a/src/lib/upside.ts
+++ b/src/lib/upside.ts
@@ -1,0 +1,108 @@
+export type UpsideType =
+  | "Umwidmung_Hotel"
+  | "Dachausbau"
+  | "Airbnb"
+  | "Sanierung_Mietanhebung"
+  | "Nachverdichtung"
+  | "Sonstiges";
+
+export interface UpsideScenario {
+  id: string;
+  active: boolean;
+  type: UpsideType;
+  title: string;
+  startYear: number;
+  addedSqm: number;
+  newRentPerSqm: number;
+  occupancyPct: number;
+  capex: number;
+  capexAfaPct?: number;
+  probabilityPct: number;
+  remarks?: string;
+}
+
+export interface UpsideCalculationResult {
+  cashflowsUpside: number[];
+  irrUpside: number;
+  irrDelta: number;
+  pAvg: number;
+  pWeighted: number;
+  bonus: number; // 0..10 points
+}
+
+/** Round a number to one decimal place */
+export const roundTo1 = (n: number): number => Math.round(n * 10) / 10;
+
+/**
+ * Internal Rate of Return via Newton-Raphson.
+ * @param cashflows Array of yearly cashflows, index 0 = Jahr 0
+ * @param guess Initial guess
+ */
+export function irr(cashflows: number[], guess = 0.1): number {
+  let rate = guess;
+  for (let i = 0; i < 1000; i++) {
+    let npv = 0;
+    let dnpv = 0;
+    for (let t = 0; t < cashflows.length; t++) {
+      const cf = cashflows[t];
+      const denom = Math.pow(1 + rate, t);
+      npv += cf / denom;
+      dnpv -= (t * cf) / (denom * (1 + rate));
+    }
+    const newRate = rate - npv / dnpv;
+    if (Math.abs(newRate - rate) < 1e-7) return newRate;
+    rate = newRate;
+  }
+  return rate;
+}
+
+/**
+ * Calculate upside cashflows and scoring.
+ * @param cashflowsBasis Basis cashflows inkl. Jahr 0
+ * @param irrBasis IRR der Basis-cashflows
+ * @param scenarios Upside-Szenarien
+ */
+export function calculateUpside(
+  cashflowsBasis: number[],
+  irrBasis: number,
+  scenarios: UpsideScenario[]
+): UpsideCalculationResult {
+  const years = cashflowsBasis.length;
+  const cashflowsUpside = [...cashflowsBasis];
+  const active = scenarios.filter((s) => s.active);
+
+  for (const s of active) {
+    const start = Math.max(0, Math.floor(s.startYear));
+    if (start >= years) continue;
+    if (s.capex > 0) {
+      cashflowsUpside[start] -= s.capex;
+    }
+    if (s.addedSqm > 0 && s.newRentPerSqm > 0) {
+      const extra =
+        s.addedSqm * s.newRentPerSqm * 12 * (s.occupancyPct / 100);
+      for (let y = start; y < years; y++) {
+        cashflowsUpside[y] += extra;
+      }
+    }
+  }
+
+  const irrUpside = irr(cashflowsUpside);
+  const irrDelta = Math.max(0, irrUpside - irrBasis);
+  const pAvg =
+    active.length > 0
+      ? active.reduce((sum, s) => sum + s.probabilityPct, 0) / active.length
+      : 0;
+  const pWeighted = irrDelta * (pAvg / 100);
+  const bonus = Math.max(0, Math.min(10, (pWeighted / 0.03) * 10));
+
+  return {
+    cashflowsUpside,
+    irrUpside,
+    irrDelta,
+    pAvg,
+    pWeighted,
+    bonus: roundTo1(bonus),
+  };
+}
+
+export default calculateUpside;


### PR DESCRIPTION
## Summary
- add IRR-based Upside scenario model and scoring utilities
- manage Upside scenarios via new hook and form components
- integrate Upside bonus into evaluation and README

## Testing
- `npm run lint`
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af2ed77c448332ac6767bdf6145deb